### PR TITLE
Some bugfixes for utils.sh

### DIFF
--- a/altpart-safestrap/utils.sh
+++ b/altpart-safestrap/utils.sh
@@ -22,9 +22,9 @@ function splitRamdiskImage
     local OFFSET=$(grep -Uboa $'\x1f\x8b\x08' \
       ${FILE} | \
       perl -pe 's/([0-9]+):.*/$1/' | head -n 2 | tail -n 1)
-    dd count=${OFFSET} bs=1 if=${ROM_RAMDISK} \
+    dd count=${OFFSET} bs=1 if=${FILE} \
       of=${OUT_DIR}/${BASE_FILE}.1.cpio.gz
-    dd skip=${OFFSET} bs=1 if=${ROM_RAMDISK} \
+    dd skip=${OFFSET} bs=1 if=${FILE} \
       of=${OUT_DIR}/${BASE_FILE}.2.cpio.gz
   )
 
@@ -55,8 +55,7 @@ function unpackRamdiskImage
   fi
 
   (
-    cd ${OUT_DIR}
-    gzip -cd ${FILE} | cpio -i
+    gzip -cd ${FILE} | cpio -i -D ${OUT_DIR}
   ) || return $?
 
   return 0
@@ -80,9 +79,8 @@ function packRamdiskImage
     return 2
   fi
 
-  (
-    cd ${IN_DIR}
-    find . | cpio -o -H newc --owner=root:root | gzip > \
+  (    
+    find ${IN_DIR} -printf '%P\n' | cpio -o -H newc --owner=root:root -D ${IN_DIR} | gzip > \
       ${FILE}
   ) || return 3
 


### PR DESCRIPTION
I wanted to use ramdisk tools in utils.sh standalone and found some issues which should be fixed with this PR:
splitRamdiskImage: wrong input file parameter
unpackRamdiskImage: unable to extract infile with relative path
packRamdiskImage: resulting cpio image was broken / will not boot because find lists base directory (./) which should not be added to archive -> fixed via printf. Additionally, outfile may now have relative path.