### PR TITLE
Make creation of patched file more robust

### DIFF
--- a/altpart-safestrap/patch-rom.sh
+++ b/altpart-safestrap/patch-rom.sh
@@ -103,6 +103,7 @@ unmount(\"/system\");\n" > \
 cp ${DIR}/update-binary ${BUILD_DIR}/META-INF/com/google/android/
 
 echo "=== Creating patch zip ========================================================="
+pushd
 cd ${BUILD_DIR}
 zip -r9 _${PATCH_FILE} system/ META-INF/
 
@@ -111,7 +112,7 @@ java -jar ${DIR}/signapk/signapk.jar ${DIR}/signapk/key.x509.pem \
   ${DIR}/signapk/key.pk8 _${PATCH_FILE} ${FILE_DIR}/${PATCH_FILE} || exit $?
 
 echo "=== Cleaning up ================================================================"
-cd ..
+popd
 rm -rf ${BUILD_DIR}
 
 echo "Done!"

--- a/altpart-safestrap/patch-rom.sh
+++ b/altpart-safestrap/patch-rom.sh
@@ -13,7 +13,7 @@ fi
 
 MD5=($(md5sum $1))
 BASE_FILE=$(basename ${FILE})
-FILE_DIR=$(dirname ${FILE})
+FILE_DIR=$(dirname `realpath ${FILE}`)
 PATCH_FILE=altpart-patch-${BASE_FILE}
 
 BUILD_DIR="/tmp/altpart-patch"

--- a/altpart-safestrap/patch-rom.sh
+++ b/altpart-safestrap/patch-rom.sh
@@ -103,8 +103,7 @@ unmount(\"/system\");\n" > \
 cp ${DIR}/update-binary ${BUILD_DIR}/META-INF/com/google/android/
 
 echo "=== Creating patch zip ========================================================="
-pushd
-cd ${BUILD_DIR}
+pushd ${BUILD_DIR}
 zip -r9 _${PATCH_FILE} system/ META-INF/
 
 echo "=== Signing patch zip =========================================================="


### PR DESCRIPTION
If patch-rom.sh is invoked with rom file residing in current directory, the patched file would be put straight into ${BUILD DIR} because dirname ${FILE} just returns '.'. Hence, the patched file would be deleted together with ${BUILD_DIR} in the end ;-)

I fixed this by adding realpath such that ${FILE_DIR} resembles an absolute path.